### PR TITLE
update.c: add the gtk-icon-theme change for rc.xml too

### DIFF
--- a/update.c
+++ b/update.c
@@ -59,6 +59,7 @@ update(GtkWidget *widget, gpointer data)
 	/* ~/.config/labwc/rc.xml */
 	xml_set_num("/labwc_config/theme/cornerradius", SPIN_BUTTON_VAL(state->widgets.corner_radius));
 	xml_set("/labwc_config/theme/name", COMBO_TEXT(state->widgets.openbox_theme_name));
+	xml_set("/labwc_config/theme/icon", COMBO_TEXT(state->widgets.icon_theme_name));
 	xml_set("/labwc_config/libinput/device/naturalscroll", COMBO_TEXT(state->widgets.natural_scroll));
 	xml_set("/labwc_config/theme/dropShadows", COMBO_TEXT(state->widgets.drop_shadows));
 	xml_set("/labwc_config/theme/titlebar/layout", (char *)GTK_ENTRY_TEXT(state->widgets.button_layout));


### PR DESCRIPTION
since labwc-0.8.2 window icons are supported, and now 0.8.3 menu icons are supported