### PR TITLE
update GTK_THEME in lab environment file

### DIFF
--- a/update.c
+++ b/update.c
@@ -73,6 +73,7 @@ update(GtkWidget *widget, gpointer data)
 	set_value(state->settings, "icon-theme", COMBO_TEXT(state->widgets.icon_theme_name));
 
 	/* ~/.config/labwc/environment */
+	environment_set("GTK_THEME", COMBO_TEXT(state->widgets.gtk_theme_name));
 	environment_set("XCURSOR_THEME", COMBO_TEXT(state->widgets.cursor_theme_name));
 	environment_set_num("XCURSOR_SIZE", SPIN_BUTTON_VAL_INT(state->widgets.cursor_size));
 	environment_set("XKB_DEFAULT_LAYOUT", first_field(COMBO_TEXT(state->widgets.keyboard_layout), ' '));


### PR DESCRIPTION
Failed attempt at achieving the desired behavior https://github.com/labwc/labwc-tweaks-gtk/issues/43 .
If `GTK_THEME` is set in the environment before launching `tweaks` the update button behaves dead. However, launching with `env -u GTK_THEME labwc-tweaks-gtk` achieves the desired result with this patch.
Apologies, Im stumped at this point on how to get there without calling `tweaks` with `env -u`. I'm probably being dumb and not reading thoroughly enough

Edit: after a full restart of `labwc`, with or without `env -u`, its the desired result. just no live update of the gtk theme.

Sidenote:  In places it looks like `tweaks` is hardcoded to read and write `~/.config/labwc/` ?
That threw me off because I launch `lab` from a non-default location. ie `labwc -C ~/.config/labwc/arch`

